### PR TITLE
Add a line-counter example, and adjust the stdlib to work with os.Args

### DIFF
--- a/examples/line_count/wc.agl
+++ b/examples/line_count/wc.agl
@@ -1,0 +1,36 @@
+package main
+
+import (
+    "fmt"
+    "os"
+    "strings"
+)
+
+// Returns the line count of a filename using a result type
+func countLines(filename string) int! {
+    data := os.ReadFile(filename)!
+    content := string(data)
+    lines := strings.Split(content, "\n")
+    
+    // Count total lines (wc -l compatible)
+    totalCount := lines.Map({ 1 }).Sum() - 1
+    
+    return Ok(totalCount)
+}
+
+func main() {
+    // Get filename from command line arguments
+    if len(os.Args) < 2 {
+        fmt.Println("usage: wc <filename>")
+        return
+    }
+    
+    filename := os.Args[1]
+    
+    match countLines(filename) {
+    case Ok(total):
+        fmt.Printf("%8d %s\n", total, filename)
+    case Err(err):
+        fmt.Printf("wc: %s: %s\n", filename, err)
+    }
+}

--- a/pkg/agl/std/os/os.agl
+++ b/pkg/agl/std/os/os.agl
@@ -31,3 +31,4 @@ func IsPathSeparator(c uint8) bool
 func IsPermission(err error) bool
 func IsTimeout(err error) bool
 func LookupEnv(key string) string?
+type Args []string


### PR DESCRIPTION
This change adds support for `os.Args`, which required a bit of adjustment to the main entrypoint so args can be passed the agl run command with a `--` delimiter like: `agl run code.agl -- program_args`


```
❯ go version
go version go1.24.4 darwin/amd64
❯ go build
❯ ./agl
You must specify a file to compile
❯ ./agl examples/line_count/wc.agl
...
```

Golang generated from the new example:
```golang
package main
import "fmt"
import "os"
import "strings"
func countLines(filename string) Result[int] {
	tmp, err := os.ReadFile(filename)
	if err != nil {
		return MakeResultErr[int](err)
	}
	data := AglIdentity(tmp)
	content := string(data)
	lines := strings.Split(content, "\n")
	totalCount := AglVecSum(AglVecMap(lines, func(aglArg0 string) int {
		return 1
	})) - 1
	return MakeResultOk(totalCount)
}
func main() {
	if len(os.Args) < 2 {
		fmt.Println("usage: wc <filename>")
		return
	}
	filename := os.Args[1]
	aglTmp1 := countLines(filename)
	if aglTmp1.IsOk() {
		total := aglTmp1.Unwrap()
		fmt.Printf("%8d %s\n", total, filename)
	}
	if aglTmp1.IsErr() {
		err := aglTmp1.Err()
		fmt.Printf("wc: %s: %s\n", filename, err)
	}
}
```


```
❯ ./agl run examples/line_count/wc.agl -- Makefile
      12 Makefile
❯ wc -l Makefile
      12 Makefile
❯ ./agl run examples/line_count/wc.agl -- nahhhh
wc: nahhhh: open nahhhh: no such file or directory
```


```
❯ make cover
	agl		coverage: 0.0% of statements
	agl/cmd/auo_wrapper		coverage: 0.0% of statements
	agl/docs		coverage: 0.0% of statements
	agl/examples/wc		coverage: 0.0% of statements
ok  	agl/pkg/agl	2.347s	coverage: 61.6% of statements in ./...
	agl/pkg/ast		coverage: 0.0% of statements
	agl/pkg/parser		coverage: 0.0% of statements
	agl/pkg/scanner		coverage: 0.0% of statements
	agl/pkg/token		coverage: 0.0% of statements
ok  	agl/pkg/types	0.058s	coverage: 0.1% of statements in ./...
	agl/pkg/utils		coverage: 0.0% of statements
```